### PR TITLE
ability to time calls

### DIFF
--- a/src/main/kotlin/com/dimdarkevil/glasnik/Config.kt
+++ b/src/main/kotlin/com/dimdarkevil/glasnik/Config.kt
@@ -3,4 +3,5 @@ package com.dimdarkevil.glasnik
 data class Config(
     var currentWorkspace: String = "",
     var editor: String = System.getenv("EDITOR") ?: "",
+    var showCallTimes: Boolean = false,
 )


### PR DESCRIPTION
Added a stopwatch function and a new (optional) `showCallTimes` config boolean (default `false`) to enable/disable reporting of how long a call took